### PR TITLE
refactor: remove uso do ResetPasswordUsecase e suas referências

### DIFF
--- a/lib/app_module.dart
+++ b/lib/app_module.dart
@@ -36,7 +36,6 @@ import 'domain/usecases/auth/login_usecase.dart';
 import 'domain/usecases/auth/register_usecase.dart';
 import 'domain/usecases/auth/logout_usecase.dart';
 import 'domain/usecases/auth/get_current_user_usecase.dart';
-import 'domain/usecases/auth/reset_password_usecase.dart';
 import 'domain/usecases/auth/update_profile_usecase.dart';
 import 'domain/usecases/auth/get_auth_state_changes_usecase.dart';
 
@@ -103,7 +102,6 @@ import 'features/shared/bloc/notification_bloc.dart';
 // Pages
 import 'features/auth/pages/login_page.dart';
 import 'features/shared/pages/notification_page.dart';
-import 'features/auth/pages/forgot_password_page.dart';
 import 'features/auth/pages/register_type_page.dart';
 import 'features/auth/pages/supervisor_register_page.dart';
 import 'features/student/pages/student_register_page.dart';
@@ -154,7 +152,6 @@ class AppModule extends Module {
     i.addLazySingleton<RegisterUsecase>(() => RegisterUsecase(i()));
     i.addLazySingleton<LogoutUsecase>(() => LogoutUsecase(i()));
     i.addLazySingleton<GetCurrentUserUsecase>(() => GetCurrentUserUsecase(i()));
-    i.addLazySingleton<ResetPasswordUsecase>(() => ResetPasswordUsecase(i()));
     i.addLazySingleton<UpdateProfileUsecase>(() => UpdateProfileUsecase(i()));
     i.addLazySingleton<GetAuthStateChangesUsecase>(
         () => GetAuthStateChangesUsecase(i()));
@@ -246,7 +243,6 @@ class AppModule extends Module {
           registerUseCase: i(),
           logoutUseCase: i(),
           getCurrentUserUseCase: i(),
-          resetPasswordUseCase: i(),
           updateProfileUseCase: i(),
           getAuthStateChangesUseCase: i(),
         ));
@@ -312,8 +308,6 @@ class AppModule extends Module {
         child: (context) => const StudentRegisterPage());
     r.child('/auth/register-supervisor',
         child: (context) => const SupervisorRegisterPage());
-    r.child('/auth/forgot-password',
-        child: (context) => const ForgotPasswordPage());
     r.child('/auth/unauthorized', child: (context) => const UnauthorizedPage());
 
     // Student Module Routes

--- a/lib/features/auth/auth_module.dart
+++ b/lib/features/auth/auth_module.dart
@@ -1,6 +1,5 @@
 // lib/features/auth/auth_module.dart
 import 'package:flutter_modular/flutter_modular.dart';
-import 'package:gestao_de_estagio/features/auth/pages/forgot_password_page.dart';
 import 'package:gestao_de_estagio/features/auth/pages/login_page.dart';
 import 'package:gestao_de_estagio/features/auth/pages/register_type_page.dart';
 import 'package:gestao_de_estagio/features/auth/pages/email_confirmation_page.dart';
@@ -15,7 +14,6 @@ class AuthModule extends Module {
   void routes(RouteManager r) {
     r.child('/', child: (context) => const LoginPage());
     r.child('/register', child: (context) => const RegisterTypePage());
-    r.child('/forgot-password', child: (context) => const ForgotPasswordPage());
     r.child('/email-confirmation',
         child: (context) => EmailConfirmationPage(
               email: r.args.data as String,

--- a/lib/features/auth/bloc/auth_bloc.dart
+++ b/lib/features/auth/bloc/auth_bloc.dart
@@ -8,7 +8,6 @@ import '../../../domain/usecases/auth/logout_usecase.dart';
 import '../../../domain/usecases/auth/get_current_user_usecase.dart';
 import '../../../domain/usecases/auth/update_profile_usecase.dart';
 import '../../../domain/usecases/auth/get_auth_state_changes_usecase.dart';
-import '../../../domain/usecases/auth/reset_password_usecase.dart';
 import 'auth_event.dart';
 import 'auth_state.dart';
 import '../../../domain/entities/user_entity.dart';
@@ -23,7 +22,6 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
   final GetCurrentUserUsecase _getCurrentUserUseCase;
   final GetAuthStateChangesUsecase _getAuthStateChangesUseCase;
   final UpdateProfileUsecase _updateProfileUseCase;
-  final ResetPasswordUsecase _resetPasswordUseCase;
   StreamSubscription<UserEntity?>? _authStateSubscription;
 
   AuthBloc({
@@ -33,14 +31,12 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     required GetCurrentUserUsecase getCurrentUserUseCase,
     required GetAuthStateChangesUsecase getAuthStateChangesUseCase,
     required UpdateProfileUsecase updateProfileUseCase,
-    required ResetPasswordUsecase resetPasswordUseCase,
   })  : _loginUseCase = loginUseCase,
         _logoutUseCase = logoutUseCase,
         _registerUseCase = registerUseCase,
         _getCurrentUserUseCase = getCurrentUserUseCase,
         _getAuthStateChangesUseCase = getAuthStateChangesUseCase,
         _updateProfileUseCase = updateProfileUseCase,
-        _resetPasswordUseCase = resetPasswordUseCase,
         super(AuthInitial()) {
     if (kDebugMode) {
       print('🟡 AuthBloc: Construtor chamado');
@@ -55,7 +51,6 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     on<AuthStateChanged>(_onAuthStateChanged);
     on<UpdateProfileRequested>(_onUpdateProfileRequested);
     on<AuthCheckRequested>(_onAuthCheckRequested);
-    on<AuthResetPasswordRequested>(_onAuthResetPasswordRequested);
 
     if (kDebugMode) {
       print('🟡 AuthBloc: Handlers registrados');
@@ -219,19 +214,6 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
         emit(const AuthProfileUpdateSuccess('Perfil atualizado com sucesso!'));
         emit(AuthSuccess(user));
       },
-    );
-  }
-
-  Future<void> _onAuthResetPasswordRequested(
-    AuthResetPasswordRequested event,
-    Emitter<AuthState> emit,
-  ) async {
-    emit(AuthLoading());
-    final result = await _resetPasswordUseCase(email: event.email);
-    result.fold(
-      (failure) => emit(AuthFailure(failure.message)),
-      (_) => emit(const AuthPasswordResetEmailSent(
-          message: 'E-mail de redefinição enviado!')),
     );
   }
 

--- a/test/features/auth/bloc/auth_bloc_test.dart
+++ b/test/features/auth/bloc/auth_bloc_test.dart
@@ -7,7 +7,6 @@ import 'package:gestao_de_estagio/domain/usecases/auth/get_current_user_usecase.
 import 'package:gestao_de_estagio/domain/usecases/auth/login_usecase.dart';
 import 'package:gestao_de_estagio/domain/usecases/auth/logout_usecase.dart';
 import 'package:gestao_de_estagio/domain/usecases/auth/register_usecase.dart';
-import 'package:gestao_de_estagio/domain/usecases/auth/reset_password_usecase.dart';
 import 'package:gestao_de_estagio/domain/usecases/auth/update_profile_usecase.dart';
 import 'package:gestao_de_estagio/features/auth/bloc/auth_bloc.dart';
 import 'package:gestao_de_estagio/features/auth/bloc/auth_event.dart';
@@ -24,7 +23,6 @@ import 'auth_bloc_test.mocks.dart';
   GetCurrentUserUsecase,
   GetAuthStateChangesUsecase,
   UpdateProfileUsecase,
-  ResetPasswordUsecase,
 ])
 void main() {
   late AuthBloc authBloc;
@@ -34,7 +32,6 @@ void main() {
   late MockGetCurrentUserUsecase mockGetCurrentUserUseCase;
   late MockGetAuthStateChangesUsecase mockGetAuthStateChangesUseCase;
   late MockUpdateProfileUsecase mockUpdateProfileUseCase;
-  late MockResetPasswordUsecase mockResetPasswordUseCase;
 
   setUp(() {
     mockLoginUseCase = MockLoginUsecase();
@@ -43,7 +40,6 @@ void main() {
     mockGetCurrentUserUseCase = MockGetCurrentUserUsecase();
     mockGetAuthStateChangesUseCase = MockGetAuthStateChangesUsecase();
     mockUpdateProfileUseCase = MockUpdateProfileUsecase();
-    mockResetPasswordUseCase = MockResetPasswordUsecase();
 
     when(mockGetAuthStateChangesUseCase.call())
         .thenAnswer((_) => const Stream.empty());
@@ -55,7 +51,6 @@ void main() {
       getCurrentUserUseCase: mockGetCurrentUserUseCase,
       getAuthStateChangesUseCase: mockGetAuthStateChangesUseCase,
       updateProfileUseCase: mockUpdateProfileUseCase,
-      resetPasswordUseCase: mockResetPasswordUseCase,
     );
   });
 

--- a/test/features/auth/bloc/auth_bloc_test.mocks.dart
+++ b/test/features/auth/bloc/auth_bloc_test.mocks.dart
@@ -21,8 +21,6 @@ import 'package:gestao_de_estagio/domain/usecases/auth/logout_usecase.dart'
     as _i7;
 import 'package:gestao_de_estagio/domain/usecases/auth/register_usecase.dart'
     as _i8;
-import 'package:gestao_de_estagio/domain/usecases/auth/reset_password_usecase.dart'
-    as _i15;
 import 'package:gestao_de_estagio/domain/usecases/auth/update_profile_usecase.dart'
     as _i14;
 import 'package:mockito/mockito.dart' as _i1;
@@ -264,33 +262,4 @@ class MockUpdateProfileUsecase extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.Either<_i5.AppFailure, _i6.UserEntity>>);
-}
-
-/// A class which mocks [ResetPasswordUsecase].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockResetPasswordUsecase extends _i1.Mock
-    implements _i15.ResetPasswordUsecase {
-  MockResetPasswordUsecase() {
-    _i1.throwOnMissingStub(this);
-  }
-
-  @override
-  _i4.Future<_i2.Either<_i5.AppFailure, void>> call({required String? email}) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #call,
-          [],
-          {#email: email},
-        ),
-        returnValue: _i4.Future<_i2.Either<_i5.AppFailure, void>>.value(
-            _FakeEither_0<_i5.AppFailure, void>(
-          this,
-          Invocation.method(
-            #call,
-            [],
-            {#email: email},
-          ),
-        )),
-      ) as _i4.Future<_i2.Either<_i5.AppFailure, void>>);
 }


### PR DESCRIPTION
- Elimina a injeção e uso do ResetPasswordUsecase em diversos arquivos, simplificando a lógica de autenticação.
- Remove a página de "esqueci a senha" e suas rotas associadas, focando na experiência do usuário e na clareza do fluxo de autenticação.